### PR TITLE
Asynchrony for CassandraBinaryService

### DIFF
--- a/src/main/java/edu/si/trellis/cassandra/CassandraBinaryService.java
+++ b/src/main/java/edu/si/trellis/cassandra/CassandraBinaryService.java
@@ -102,16 +102,14 @@ public class CassandraBinaryService implements BinaryService {
     @Override
     public Optional<InputStream> getContent(IRI identifier, List<Range<Integer>> ranges) {
         requireNonNull(ranges, "Byte ranges may not be null!");
+        if (ranges.isEmpty()) throw new IllegalArgumentException("ranges cannot be empty!");
+
         // TODO https://github.com/trellis-ldp/trellis/issues/148
         try {
-            return Optional.of(_getContent(identifier, ranges).get());
+            return Optional.of(readRanges(identifier, ranges).get());
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeTrellisException(e);
         }
-    }
-
-    private CompletableFuture<InputStream> _getContent(IRI identifier, List<Range<Integer>> ranges) {
-        return ranges.isEmpty() ? readAll(identifier) : readRanges(identifier, ranges);
     }
 
     private Executor translator = Runnable::run;
@@ -124,6 +122,16 @@ public class CassandraBinaryService implements BinaryService {
                 throw new RuntimeTrellisException(e);
             }
         }, translator);
+    }
+
+    @Override
+    public Optional<InputStream> getContent(IRI identifier) {
+        // TODO https://github.com/trellis-ldp/trellis/issues/148
+        try {
+            return Optional.of(readAll(identifier).get());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeTrellisException(e);
+        }
     }
 
     private CompletableFuture<InputStream> readAll(IRI identifier) {

--- a/src/main/java/edu/si/trellis/cassandra/CassandraResource.java
+++ b/src/main/java/edu/si/trellis/cassandra/CassandraResource.java
@@ -5,10 +5,14 @@ import static edu.si.trellis.cassandra.CassandraResourceService.Mutability.Meta;
 import static edu.si.trellis.cassandra.CassandraResourceService.Mutability.Mutable;
 import static java.util.Objects.requireNonNull;
 
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Spliterator;
-import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -20,11 +24,6 @@ import org.trellisldp.api.Binary;
 import org.trellisldp.api.RDFUtils;
 import org.trellisldp.api.Resource;
 import org.trellisldp.vocabulary.LDP;
-
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Session;
 
 public class CassandraResource implements Resource {
 

--- a/src/main/java/edu/si/trellis/cassandra/DatasetCodec.java
+++ b/src/main/java/edu/si/trellis/cassandra/DatasetCodec.java
@@ -21,13 +21,13 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.core.utils.Bytes;
 
-public class DatasetCodec extends TypeCodec<Dataset> {
+class DatasetCodec extends TypeCodec<Dataset> {
     
-    public static final DatasetCodec datasetCodec = new DatasetCodec();
+    static final DatasetCodec datasetCodec = new DatasetCodec();
 
     private static final JenaRDF rdf = new JenaRDF();
     
-    public DatasetCodec() {
+    private DatasetCodec() {
         super(DataType.text(), Dataset.class);
     }
 

--- a/src/main/java/edu/si/trellis/cassandra/IRICodec.java
+++ b/src/main/java/edu/si/trellis/cassandra/IRICodec.java
@@ -11,8 +11,10 @@ import com.datastax.driver.core.TypeCodec;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.core.utils.Bytes;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
@@ -63,7 +65,7 @@ class IRICodec extends TypeCodec<IRI> {
 
     @Override
     public IRI deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) throws InvalidTypeException {
-        return bytes == null || bytes.remaining() == 0 ? null : parse(new String(Bytes.getArray(bytes), UTF_8));
+        return bytes == null ? null : parse(new String(Bytes.getArray(bytes), UTF_8));
     }
 
     @Override
@@ -71,7 +73,7 @@ class IRICodec extends TypeCodec<IRI> {
         if (v == null || v.isEmpty()) return null;
         try {
             return cache.get(v);
-        } catch (Exception e) {
+        } catch (ExecutionException|UncheckedExecutionException e) {
             throw new InvalidTypeException("Bad URI!", e);
         }
     }

--- a/src/main/java/edu/si/trellis/cassandra/IRICodec.java
+++ b/src/main/java/edu/si/trellis/cassandra/IRICodec.java
@@ -24,12 +24,12 @@ import org.trellisldp.api.RDFUtils;
  * @author ajs6f
  *
  */
-public class IRICodec extends TypeCodec<IRI> {
+class IRICodec extends TypeCodec<IRI> {
 
     /**
      * Singleton instance.
      */
-    public static final IRICodec iriCodec = new IRICodec();
+    static final IRICodec iriCodec = new IRICodec();
 
     protected static final int cacheConcurrencyLevel = 16;
 
@@ -43,7 +43,7 @@ public class IRICodec extends TypeCodec<IRI> {
     /**
      * Default constructor.
      */
-    public IRICodec() {
+    private IRICodec() {
         super(DataType.text(), IRI.class);
     }
 

--- a/src/main/java/edu/si/trellis/cassandra/InputStreamCodec.java
+++ b/src/main/java/edu/si/trellis/cassandra/InputStreamCodec.java
@@ -1,0 +1,62 @@
+package edu.si.trellis.cassandra;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.driver.core.utils.Bytes;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Serializes {@link InputStream}s in Cassandra text fields.
+ *
+ */
+class InputStreamCodec extends TypeCodec<InputStream> {
+    
+    public static final InputStreamCodec inputStreamCodec = new InputStreamCodec();
+
+    private InputStreamCodec() {
+        super(DataType.blob(), InputStream.class);
+    }
+
+    @Override
+    public ByteBuffer serialize(InputStream value, ProtocolVersion protocolVersion) {
+        return ByteBuffer.wrap(toBytes(value));
+    }
+
+    @Override
+    public InputStream deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+        return fromBytes(Bytes.getArray(bytes));
+    }
+
+    @Override
+    public InputStream parse(String value) throws InvalidTypeException {
+        return fromBytes(value.getBytes(UTF_8));
+    }
+
+    private static InputStream fromBytes(byte[] bytes) {
+        return new ByteArrayInputStream(bytes);
+    }
+    
+    private static byte[] toBytes(InputStream in) {
+        try {
+            return IOUtils.toByteArray(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+    
+    @Override
+    public String format(InputStream in) throws InvalidTypeException {
+        return new String(toBytes(in), UTF_8);
+    }
+}

--- a/src/test/java/edu/si/trellis/cassandra/CassandraBinaryServiceIT.java
+++ b/src/test/java/edu/si/trellis/cassandra/CassandraBinaryServiceIT.java
@@ -1,5 +1,9 @@
 package edu.si.trellis.cassandra;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.io.CountingInputStream;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,8 +24,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.CountingInputStream;
 
 public class CassandraBinaryServiceIT extends Assert {
 
@@ -57,7 +59,7 @@ public class CassandraBinaryServiceIT extends Assert {
         Optional<InputStream> got2 = connection.binaryService.getContent(id, ranges);
         assertTrue(got2.isPresent());
         InputStream is = got2.get();
-        String reply2 = IOUtils.toString(is, "utf-8");
+        String reply2 = IOUtils.toString(is, UTF_8);
         assertEquals(content.subSequence(5, 12), reply2);
     }
     
@@ -92,7 +94,7 @@ public class CassandraBinaryServiceIT extends Assert {
         connection.binaryService.setContent(id, input);
         
         List<Range<Integer>> ranges = new ArrayList<>();
-        // bytes=0-835583
+        // bytes=500-835583
         // bytes=835584-1048576  (1 * 1024 * 1024)
         // FIXME: Range requests can be one sided, i.e. bytes=-900 for last 900 bytes, or 900- for bytes 900 on.
         ranges.add(Range.between(500, 835583));

--- a/src/test/java/edu/si/trellis/cassandra/CassandraConnection.java
+++ b/src/test/java/edu/si/trellis/cassandra/CassandraConnection.java
@@ -3,6 +3,7 @@ package edu.si.trellis.cassandra;
 import static com.datastax.driver.core.Cluster.builder;
 import static edu.si.trellis.cassandra.DatasetCodec.datasetCodec;
 import static edu.si.trellis.cassandra.IRICodec.iriCodec;
+import static edu.si.trellis.cassandra.InputStreamCodec.inputStreamCodec;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.junit.rules.ExternalResource;
@@ -43,7 +44,7 @@ class CassandraConnection extends ExternalResource {
     @Override
     protected void before() {
         cluster = builder().withoutMetrics().addContactPoint(contactLocation).withPort(port).build();
-        codecRegistry().register(iriCodec, datasetCodec, InstantCodec.instance);
+        codecRegistry().register(inputStreamCodec, iriCodec, datasetCodec, InstantCodec.instance);
         session = cluster.connect(keyspace);
         service = new CassandraResourceService(session);
         // UUIDGenerator idService = new UUIDGenerator();

--- a/src/test/java/edu/si/trellis/cassandra/DatasetCodecTest.java
+++ b/src/test/java/edu/si/trellis/cassandra/DatasetCodecTest.java
@@ -1,5 +1,7 @@
 package edu.si.trellis.cassandra;
 
+import static edu.si.trellis.cassandra.DatasetCodec.datasetCodec;
+
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
@@ -18,7 +20,7 @@ public class DatasetCodecTest extends Assert {
 
     @Test(expected = InvalidTypeException.class)
     public void badParse() {
-        new DatasetCodec().parse("SGDF   &&$$$dfshgou;sdfhgoudfhogh");
+        datasetCodec.parse("SGDF   &&$$$dfshgou;sdfhgoudfhogh");
     }
 
     @Test
@@ -30,7 +32,7 @@ public class DatasetCodecTest extends Assert {
         String nQuad3 = "<s> <p> <o> <g2> .";
         Quad q3 = quad(iri("g2"), iri("s"), iri("p"), iri("o"));
         String nQuads = String.join("\n", nQuad1, nQuad2, nQuad3);
-        try (Dataset dataset = new DatasetCodec().parse(nQuads)) {
+        try (Dataset dataset = datasetCodec.parse(nQuads)) {
             assertEquals(3, dataset.size());
             for (Quad q : new Quad[] { q1, q2, q3 })
                 assertTrue(dataset.contains(q));
@@ -39,10 +41,10 @@ public class DatasetCodecTest extends Assert {
 
     @Test
     public void nullForNull() {
-        assertEquals(0, new DatasetCodec().parse(null).size());
-        assertEquals(null, new DatasetCodec().format(null));
-        assertEquals(null, new DatasetCodec().serialize(null, null));
-        assertEquals(0, new DatasetCodec().deserialize(null, null).size());
+        assertEquals(0, datasetCodec.parse(null).size());
+        assertEquals(null, datasetCodec.format(null));
+        assertEquals(null, datasetCodec.serialize(null, null));
+        assertEquals(0, datasetCodec.deserialize(null, null).size());
     }
 
     private Quad quad(BlankNodeOrIRI g, BlankNodeOrIRI s, IRI p, RDFTerm o) {

--- a/src/test/java/edu/si/trellis/cassandra/IRICodecTest.java
+++ b/src/test/java/edu/si/trellis/cassandra/IRICodecTest.java
@@ -1,12 +1,14 @@
 package edu.si.trellis.cassandra;
 
+import static edu.si.trellis.cassandra.IRICodec.iriCodec;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.simple.SimpleRDF;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 public class IRICodecTest extends Assert {
 
@@ -14,21 +16,21 @@ public class IRICodecTest extends Assert {
 
     @Test(expected = InvalidTypeException.class)
     public void badParse() {
-        new IRICodec().parse("SGDF   &&$$$dfshgou;sdfhgoudfhogh");
+        iriCodec.parse("SGDF   &&$$$dfshgou;sdfhgoudfhogh");
     }
 
     @Test
     public void testParse() {
         IRI iri = rdf.createIRI("http://example.com");
         String fieldForm = iri.getIRIString();
-        assertEquals(iri, new IRICodec().parse(fieldForm));
+        assertEquals(iri, iriCodec.parse(fieldForm));
     }
 
     @Test
     public void nullForNull() {
-        assertEquals(null, new IRICodec().parse(null));
-        assertEquals(null, new IRICodec().format(null));
-        assertEquals(null, new IRICodec().serialize(null, null));
-        assertEquals(null, new IRICodec().deserialize(null, null));
+        assertEquals(null, iriCodec.parse(null));
+        assertEquals(null, iriCodec.format(null));
+        assertEquals(null, iriCodec.serialize(null, null));
+        assertEquals(null, iriCodec.deserialize(null, null));
     }
 }


### PR DESCRIPTION
@acoburn @gregjan If you have a chance take a look at this. I'm updating @gregjan's work to use the Cassandra driver's asynchronous execution. Why would this interest y'all? Because of https://github.com/trellis-ldp/trellis/issues/148. I think this is a good example of what stuff will end up looking like if we go to a `Future`-based API. WDYT? I think it's pretty reasonable.