### PR TITLE
Add build support for JDK 11

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -131,13 +131,6 @@
       <version>1.3.2</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-atinject_1.0_spec</artifactId>
-      <version>1.0</version>
->>>>>>> Add build support for JDK 11
-    </dependency>
-
     <!-- test gear -->
     <dependency>
       <groupId>junit</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.1</version>
+        <version>0.8.2</version>
         <executions>
           <execution>
             <id>default-prepare-agent</id>
@@ -123,6 +123,19 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>26.0-jre</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-atinject_1.0_spec</artifactId>
+      <version>1.0</version>
+>>>>>>> Add build support for JDK 11
     </dependency>
 
     <!-- test gear -->

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,11 @@
       <plugins>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.0</version>
+          <version>2.22.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.0</version>
+          <version>2.22.1</version>
           <configuration>
             <trimStackTrace>false</trimStackTrace>
           </configuration>
@@ -147,6 +147,15 @@
               <groupId>org.apache.cassandra</groupId>
               <artifactId>cassandra-all</artifactId>
               <version>${cassandra.test.version}</version>
+            </dependency>
+            <!-- Note: version 3.6 of cassandra-maven-plugin has a transitive dependency
+                 on an older version of com.github.jbellis/jamm, which doesn't work
+                 in JDK 11 environments. For now, force the use of latest version of
+                 this library. -->
+            <dependency>
+              <groupId>com.github.jbellis</groupId>
+              <artifactId>jamm</artifactId>
+              <version>0.3.2</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
This makes it possible to build and test `trellis-cassandra` on JDK 11 environments. The only part that isn't entirely straight-forward has a note attached to it, which may be cleaned up at some future time.