### PR TITLE
Using no-op impls out of the box

### DIFF
--- a/webapp/src/main/resources/META-INF/beans.xml
+++ b/webapp/src/main/resources/META-INF/beans.xml
@@ -3,6 +3,9 @@
   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1"
   bean-discovery-mode="all">
   <alternatives>
-<!--     <class>class org.trellisldp.api.NoopMementoService</class> -->
+    <class>org.trellisldp.api.NoopCacheService</class>
+    <class>org.trellisldp.api.NoopAuditService</class>
+    <class>org.trellisldp.api.NoopEventService</class>
+    <class>org.trellisldp.api.NoopNamespaceService</class>
   </alternatives>
 </beans>


### PR DESCRIPTION
Accompanies https://github.com/trellis-ldp/trellis/pull/416

@gregjan To use this as a starting point, just add `trellis-webac` and `trellis-jms` in Maven and overlay a new `beans.xml` which doesn't block those impls with no-ops, which all can and should be a profile in `pom.xml`, for now.