### PR TITLE
Some updates to align with upstream

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-api</artifactId>
-      <version>${trellis.version}</version>
     </dependency>
 
     <dependency>
@@ -34,7 +33,6 @@
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-vocabulary</artifactId>
-      <version>${trellis.version}</version>
     </dependency>
 
     <dependency>
@@ -66,7 +64,6 @@
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-test</artifactId>
-      <version>${trellis.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/impl/src/main/java/edu/si/trellis/CassandraBinary.java
+++ b/impl/src/main/java/edu/si/trellis/CassandraBinary.java
@@ -43,12 +43,12 @@ public class CassandraBinary implements Binary {
     }
 
     @Override
-    public CompletionStage<InputStream> getContent() {
-        return completedFuture(read.execute(id));
+    public InputStream getContent() {
+        return read.execute(id);
     }
 
     @Override
-    public CompletionStage<InputStream> getContent(int from, int to) {
+    public InputStream getContent(int from, int to) {
         int firstChunk = from / chunkLength;
         int lastChunk = to / chunkLength;
         int chunkStreamStart = from % chunkLength;
@@ -60,6 +60,6 @@ public class CassandraBinary implements Binary {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } // we needn't check the result; see BinaryReadQuery#retrieve
-        return completedFuture(new BoundedInputStream(retrieve, rangeSize)); // apply limit for upper end of range
+        return new BoundedInputStream(retrieve, rangeSize); // apply limit for upper end of range
     }
 }

--- a/impl/src/test/java/edu/si/trellis/CassandraBinaryServiceIT.java
+++ b/impl/src/test/java/edu/si/trellis/CassandraBinaryServiceIT.java
@@ -42,12 +42,12 @@ class CassandraBinaryServiceIT extends CassandraServiceIT {
             connection.binaryService.setContent(builder(id).build(), testInput).join();
         }
 
-        try (InputStream got = connection.binaryService.get(id).join().getContent().toCompletableFuture().join()) {
+        try (InputStream got = connection.binaryService.get(id).join().getContent()) {
             String reply = IOUtils.toString(got, UTF_8);
             assertEquals(content, reply);
         }
 
-        try (InputStream got = connection.binaryService.get(id).join().getContent(5, 11).toCompletableFuture().join()) {
+        try (InputStream got = connection.binaryService.get(id).join().getContent(5, 11)) {
             String reply = IOUtils.toString(got, UTF_8);
             assertEquals(content.subSequence(5, 12), reply);
         }
@@ -77,11 +77,11 @@ class CassandraBinaryServiceIT extends CassandraServiceIT {
         assertTrue(got.isDone());
 
         try (InputStream testData = new FileInputStream("src/test/resources/test.jpg");
-             InputStream content = binary.getContent().toCompletableFuture().join()) {
+             InputStream content = binary.getContent()) {
             assertTrue(contentEquals(testData, content), "Didn't retrieve correct content!");
         }
 
-        try (InputStream content = binary.getContent().toCompletableFuture().join()) {
+        try (InputStream content = binary.getContent()) {
             String digest = DigestUtils.md5Hex(content);
             assertEquals(md5sum, digest);
         }
@@ -102,11 +102,11 @@ class CassandraBinaryServiceIT extends CassandraServiceIT {
         assertTrue(got.isDone());
 
         try (InputStream testData = new FileInputStream("src/test/resources/test.jpg");
-             InputStream content = binary.getContent().toCompletableFuture().join()) {
+             InputStream content = binary.getContent()) {
             assertTrue(contentEquals(testData, content), "Didn't retrieve correct content!");
         }
 
-        try (InputStream content = binary.getContent().toCompletableFuture().join()) {
+        try (InputStream content = binary.getContent()) {
             String digest = DigestUtils.md5Hex(content);
             assertEquals(md5sum, digest);
         }

--- a/impl/src/test/java/edu/si/trellis/CassandraBinaryTest.java
+++ b/impl/src/test/java/edu/si/trellis/CassandraBinaryTest.java
@@ -75,7 +75,7 @@ class CassandraBinaryTest {
         when(mockRead.execute(any())).thenReturn(mockInputStream1);
         CassandraBinary testCassandraBinary = new CassandraBinary(testId, mockRead, mockReadRange, testChunkSize);
 
-        final InputStream result = testCassandraBinary.getContent().toCompletableFuture().join();
+        final InputStream result = testCassandraBinary.getContent();
         assertSame(mockInputStream1, result, "Got wrong InputStream!");
     }
 
@@ -86,7 +86,7 @@ class CassandraBinaryTest {
         when(mockReadRange.execute(any(), anyInt(), anyInt())).thenReturn(testInputStream);
         CassandraBinary testCassandraBinary = new CassandraBinary(testId, mockRead, mockReadRange, testChunkSize);
 
-        final InputStream content = testCassandraBinary.getContent(0, 10).toCompletableFuture().join();
+        final InputStream content = testCassandraBinary.getContent(0, 10);
         byte[] result = new byte[3];
 
         content.read(result);

--- a/impl/src/test/java/edu/si/trellis/CassandraServiceIT.java
+++ b/impl/src/test/java/edu/si/trellis/CassandraServiceIT.java
@@ -1,8 +1,8 @@
 package edu.si.trellis;
 
 import static java.lang.Boolean.TRUE;
+import static java.time.Duration.ofSeconds;
 import static org.awaitility.Awaitility.await;
-import static org.awaitility.Duration.TWO_SECONDS;
 
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
@@ -21,6 +21,6 @@ class CassandraServiceIT {
     }
 
     protected void waitTwoSeconds() {
-        await().pollDelay(TWO_SECONDS).until(() -> TRUE);
+        await().pollDelay(ofSeconds(2)).until(() -> TRUE);
     }
 }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -41,14 +41,7 @@
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-test</artifactId>
-      <version>${trellis.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- needed to support trellis-test -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <cassandra.test.version>3.11.3</cassandra.test.version>
     <cassandra.driver.version>3.7.0</cassandra.driver.version>
-    <jena.version>3.12.0</jena.version>
+    <jena.version>3.13.1</jena.version>
     <commons.rdf.version>0.5.0</commons.rdf.version>
     <thorntail.version>2.4.0.Final</thorntail.version>
     <tamaya.version>0.4-incubating-SNAPSHOT</tamaya.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.trellisldp</groupId>
+        <artifactId>trellis-bom</artifactId>
+        <version>${trellis.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.3.2</version>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -70,10 +70,6 @@
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
-      <artifactId>trellis-agent</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.trellisldp</groupId>
       <artifactId>trellis-webdav</artifactId>
     </dependency>
 

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -55,50 +55,26 @@
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-http</artifactId>
-      <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-constraint-rules</artifactId>
-      <version>${trellis.version}</version>
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-rdfa</artifactId>
-      <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-io-jena</artifactId>
-      <version>${trellis.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tamaya</groupId>
-          <artifactId>tamaya-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-agent</artifactId>
-      <version>${trellis.version}</version>
     </dependency>
     <dependency>
       <groupId>org.trellisldp</groupId>
       <artifactId>trellis-webdav</artifactId>
-      <version>${trellis.version}</version>
     </dependency>
 
   <!-- Configuration -->

--- a/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
+++ b/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
@@ -7,7 +7,6 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import org.trellisldp.api.*;
-import org.trellisldp.http.core.EtagGenerator;
 import org.trellisldp.http.core.ServiceBundler;
 import org.trellisldp.http.core.TimemapGenerator;
 import org.trellisldp.io.JenaIOService;
@@ -52,9 +51,6 @@ public class CassandraServiceBundler implements ServiceBundler {
     private TimemapGenerator timemapGenerator;
 
     @Inject
-    private EtagGenerator etagGenerator;
-
-    @Inject
     private Instance<ConstraintService> constraintServices;
 
     @PostConstruct
@@ -95,11 +91,6 @@ public class CassandraServiceBundler implements ServiceBundler {
     @Override
     public EventService getEventService() {
         return eventService;
-    }
-
-    @Override
-    public EtagGenerator getEtagGenerator() {
-        return etagGenerator;
     }
 
     @Override

--- a/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
+++ b/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
@@ -19,6 +19,7 @@ import org.trellisldp.io.JenaIOService;
 public class CassandraServiceBundler implements ServiceBundler {
 
     @Inject
+    @NoopImplementation
     private AuditService auditService;
 
     @Inject
@@ -39,6 +40,7 @@ public class CassandraServiceBundler implements ServiceBundler {
     private IOService ioService;
 
     @Inject
+    @NoopImplementation
     private EventService eventService;
 
     @Inject
@@ -50,9 +52,12 @@ public class CassandraServiceBundler implements ServiceBundler {
     @Inject
     private Instance<ConstraintService> constraintServices;
 
+    @Inject
+    private RDFaWriterService rdfaService;
+
     @PostConstruct
     void init() {
-        this.ioService = new JenaIOService(namespaceService, null, cacheService, "", "");
+        this.ioService = new JenaIOService(namespaceService, rdfaService, cacheService, "", "");
     }
 
     @Override

--- a/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
+++ b/webapp/src/main/java/edu/si/trellis/CassandraServiceBundler.java
@@ -30,9 +30,6 @@ public class CassandraServiceBundler implements ServiceBundler {
     @Inject
     private CassandraBinaryService binaryService;
 
-    @Inject
-    private AgentService agentService;
-
     @Produces
     @ApplicationScoped
     private NamespaceService namespaceService = new NoopNamespaceService();
@@ -56,11 +53,6 @@ public class CassandraServiceBundler implements ServiceBundler {
     @PostConstruct
     void init() {
         this.ioService = new JenaIOService(namespaceService, null, cacheService, "", "");
-    }
-
-    @Override
-    public AgentService getAgentService() {
-        return agentService;
     }
 
     @Override

--- a/webapp/src/main/resources/META-INF/beans.xml
+++ b/webapp/src/main/resources/META-INF/beans.xml
@@ -2,9 +2,4 @@
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1"
   bean-discovery-mode="all">
-  <alternatives>
-    <class>org.trellisldp.api.NoopAuditService</class>
-    <class>org.trellisldp.api.NoopEventService</class>
-    <class>org.trellisldp.api.NoopNamespaceService</class>
-  </alternatives>
 </beans>


### PR DESCRIPTION
This makes use of the `trellis-bom` artifact trellis-ldp/trellis#501
This adjusts the `Binary::getContent` method as per trellis-ldp/trellis#510
This also removes the `EtagGenerator` interface that was removed in trellis-ldp/trellis#497